### PR TITLE
Implement missing method convert_accented_entities

### DIFF
--- a/lib/sinew/main.rb
+++ b/lib/sinew/main.rb
@@ -175,7 +175,7 @@ module Sinew
         s = s.to_s
       end
       s = TextUtil.untag(s)
-      s = s.convert_accented_entities
+      s = TextUtil.convert_accented_entities(s)
       s = TextUtil.unent(s)
       s = s.to_ascii.squish
       s

--- a/lib/sinew/text_util.rb
+++ b/lib/sinew/text_util.rb
@@ -37,11 +37,14 @@ module Sinew
                                                  "&#160;" => " ",
                                                  "&#8232;" => "\n"
                                                  )
-    
+    ACCENTED_ENTITIES = [
+      "grave", "acute", "circ", "tilde", "uml", "ring", "cedil", "slash"
+    ]
+
     #
     # tidy/clean
     #
-    
+
     def html_tidy(s)
       # run tidy
       args = TIDY_OPTIONS.map { |k, v| "#{k} #{v}" }.join(" ")
@@ -91,11 +94,15 @@ module Sinew
     end
 
     def untag(s)
-      s.gsub(/<[^>]+>/, " ")    
+      s.gsub(/<[^>]+>/, " ")
     end
 
     def unent(s)
       s.gsub(/&#?[a-z0-9]{2,};/) { |i| COMMON_ENTITIES_INV[i] }
+    end
+
+    def convert_accented_entities(s)
+      s.sub(/&([A-Za-z])(#{ACCENTED_ENTITIES.join('|')});/, '\1')
     end
   end
 end

--- a/test/test_text_util.rb
+++ b/test/test_text_util.rb
@@ -19,5 +19,10 @@ module Sinew
       # attributes preserved
       assert(clean =~ /will_be_preserved/)
     end
+
+    def test_convert_accented_entities
+      assert_equal 'a', TextUtil.convert_accented_entities("&aacute;")
+      assert_equal 'c', TextUtil.convert_accented_entities("&ccedil;")
+    end
   end
 end


### PR DESCRIPTION
Sinew::Main#_normalize was expecting convert_accented_entities to be defined for string objects.  My guess is that one of the gems used by sinew used to define it.  Since it's no longer defined, I added it to Sinew::TextUtil.
